### PR TITLE
Add test URL parsing

### DIFF
--- a/openqa-mon.8
+++ b/openqa-mon.8
@@ -84,6 +84,14 @@ Continuously monitor the jobs 42 and the jobs from 1335 to 1339. Refresh every 5
 Continuously monitor the job 42. Refresh every 5 seconds. Ring bell and displays desktop notification on status changes.
 Follow job, if it gets restarted.
 
+.TP
+.nf
+.B openqa-mon http://openqa.opensuse.org/t1245
+.B openqa-mon http://openqa.opensuse.org/tests/1245
+.TP
+.PP
+Monitor job 1245 on instance http://openqa.opensuse.org/.
+
 
 .SH COPYRIGHT
 .PP
@@ -95,7 +103,7 @@ Creator: Felix Niederwanger <felix.niederwanger@suse.de>
 
 Thanks for the constructive feedback to (in no particular order)
 
-- Christian Dywan - Pavel Dostal - Oliver Kurz - George Gkioulis -
+- Christian Dywan - Pavel Dostal - Oliver Kurz - George Gkioulis - Jozef Pupava -
 
 This tool has been created to help me and my colleagues work better with openQA.
 


### PR DESCRIPTION
This commit adds the ability to use direct test URIs (e.g. 'http://phoenix-openqa.qam.suse.de/tests/1244')
The program parses it and detects the remote and corresponding test id.