### PR TITLE
Add config file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: all
 all: openqa-mon
-openqa-mon: cmd/openqa-mon/openqa-mon.go cmd/openqa-mon/terminal.go cmd/openqa-mon/jobs.go
+openqa-mon: cmd/openqa-mon/openqa-mon.go cmd/openqa-mon/terminal.go cmd/openqa-mon/jobs.go cmd/openqa-mon/config.go
 	go build $^
 
 install: openqa-mon

--- a/cmd/openqa-mon/config.go
+++ b/cmd/openqa-mon/config.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Config struct {
+	DefaultRemote string // Default remote to take, if not otherwise defined
+	Continuous    int    // If >0, set continuous monitoring with this interval in seconds
+	Bell          bool   // bell enabled by default
+	Notify        bool   // notify enabled by default
+	Follow        bool   // follow jobs by default
+}
+
+func strBool(text string) (bool, error) {
+	value := strings.ToLower(strings.TrimSpace(text))
+	trueValues := []string{"true", "1", "on", "yes", "positive"}
+	falseValues := []string{"false", "0", "off", "no", "negative"}
+	for _, v := range trueValues {
+		if value == v {
+			return true, nil
+		}
+	}
+	for _, v := range falseValues {
+		if value == v {
+			return false, nil
+		}
+	}
+	return true, fmt.Errorf("Illegal bool value")
+}
+
+// readConfig reads file configuration from filename (if exists) and sets the values in config accordingly
+func readConfig(filename string, config *Config) error {
+	var err error
+
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return nil
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	iLine := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		iLine++
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		i := strings.Index(line, "=")
+		if i < 0 {
+			return fmt.Errorf("Config file syntax error (Line %d)", iLine)
+		}
+		name := strings.ToLower(strings.TrimSpace(line[:i]))
+		value := strings.TrimSpace(line[i+1:])
+
+		switch name {
+		case "defaultremote":
+			config.DefaultRemote = value
+		case "bell":
+			config.Bell, err = strBool(value)
+			if err != nil {
+				return fmt.Errorf("%s (Line %d)", err, iLine)
+			}
+		case "notification", "notify":
+			config.Notify, err = strBool(value)
+			if err != nil {
+				return fmt.Errorf("%s (Line %d)", err, iLine)
+			}
+		case "follow":
+			config.Follow, err = strBool(value)
+			if err != nil {
+				return fmt.Errorf("%s (Line %d)", err, iLine)
+			}
+		case "continuous":
+			config.Continuous, err = strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("%s (Line %d)", err, iLine)
+			}
+		default:
+			return fmt.Errorf("Config file illegal entry (Line %d)", iLine)
+		}
+	}
+
+	return scanner.Err()
+}

--- a/doc/openqa-mon.8
+++ b/doc/openqa-mon.8
@@ -38,6 +38,51 @@ Enable desktop notifications (sent via notify-send)
 Follow jobs, i.e. replace jobs by their clones if available.
 This setting is useful to track jobs also if they are going to be restarted in openQA.
 
+.TP
+.B --config FILE
+Reads additional config file FILE. See CONFIG FILES for details.
+
+
+.SH CONFIG FILES
+
+.TP
+openqa-mon reads by default the following configuration files:
+/etc/openqa/openqa-mon.conf (global config) or in  ~/.openqa-mon.conf (user config).
+.TP
+An example configuration file looks like the following:
+
+
+.BR "## openqa-mon config file"
+.br
+.BR "## "
+.br
+.BR "## this is an example config file for openqa-mon. Modify and place this file in"
+.br
+.BR "## /etc/openqa/openqa-mon.conf (global) or in ~/.openqa-mon.conf (user config)"
+.br
+.BR "## "
+.br
+.BR "## Have a lot of fun ..."
+.br
+.br
+.br
+.BR "## Default remote to use, if nothing is defined"
+.br
+.BR "# DefaultRemote = http://openqa.opensuse.org"
+.br
+.BR "## Enable bell notifications"
+.br
+.BR "# Bell = true"
+.br
+.BR "## Enable desktop notifications"
+.br
+.BR "# Notification = true"
+.br
+.BR "## Follow jobs"
+.br
+.BR "# Follow = true"
+.br
+
 .SH EXAMPLES
 
 .TP

--- a/openqa-mon.conf
+++ b/openqa-mon.conf
@@ -1,0 +1,16 @@
+## openqa-mon config file
+## 
+## this is an example config file for openqa-mon. Modify and place this file in
+## /etc/openqa/openqa-mon.conf (global) or in ~/.openqa-mon.conf (user config)
+## 
+## Have a lot of fun ...
+
+
+## Default remote to use, if nothing is defined
+# DefaultRemote = http://openqa.opensuse.org
+## Enable bell notifications
+# Bell = true
+## Enable desktop notifications
+# Notification = true
+## Follow jobs
+# Follow = true


### PR DESCRIPTION
This commit implements config files (global and user config)

Upon startup, openqa-mon reads `/etc/openqa/openqa-mon.conf` (global config) and  `~/.openqa-mon.conf` (user config) in this order and applies the default settings set there.