### PR TITLE
Add openqa-mq tool

### DIFF
--- a/.github/workflows/openqa-mon.go
+++ b/.github/workflows/openqa-mon.go
@@ -1,0 +1,19 @@
+name: openqa-mon
+on: push
+
+jobs:
+  openqa-mon:
+    name: openqa-mon
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+      - name: Install requirements
+        run: echo "No requirements"
+      - name: Build openqa-mon
+        run: make openqa-mon
+

--- a/.github/workflows/openqa-mon.yml
+++ b/.github/workflows/openqa-mon.yml
@@ -1,3 +1,5 @@
+---
+
 name: openqa-mon
 on: push
 
@@ -16,4 +18,17 @@ jobs:
         run: echo "No requirements"
       - name: Build openqa-mon
         run: make openqa-mon
-
+  openqa-mq:
+    name: openqa-mq
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+      - name: Install requirements
+        run: go get github.com/streadway/amqp
+      - name: Build openqa-mq
+        run: make openqa-mq

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 default: all
-all: openqa-mon
+all: openqa-mon openqa-mq
 openqa-mon: cmd/openqa-mon/openqa-mon.go cmd/openqa-mon/terminal.go cmd/openqa-mon/jobs.go cmd/openqa-mon/config.go
-	go build $^
+	go build -o openqa-mon $^
+openqa-mq: cmd/openqa-mq/openqa-mq.go
+	go build -o $@ $^
 
 install: openqa-mon
 	install openqa-mon /usr/local/bin
+	install openqa-mq /usr/local/bin
 	install doc/openqa-mon.8 /usr/local/man/man8/
 uninstall:
 	rm -f /usr/local/bin/openqa-mon
+	rm -f /usr/local/bin/openqa-mq
 	rm -f /usr/local/man/man8/openqa-mon.8

--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/streadway/amqp"
+)
+
+func printUsage() {
+	fmt.Printf("Usage: %s [REMOTE] [KEY]\n", os.Args[0])
+	fmt.Println("  REMOTE - RabbitMQ address (e.g. amqps://opensuse:opensuse@rabbit.opensuse.org)")
+	fmt.Println("  KEY - Queue key to bind to (e.g. opensuse.openqa.# for all openQA messages)")
+	fmt.Println("")
+	fmt.Println("Use 'opensuse','o3' or 'ooo' as REMOTE declaration for openSUSE, or 'osd' for the internal openQA instance")
+}
+
+// Returns the remote host from a RabbitMQ URL
+func rabbitRemote(remote string) string {
+	i := strings.Index(remote, "@")
+	if i > 0 {
+		return remote[i+1:]
+	}
+	return remote
+}
+
+func main() {
+	// Default: openSUSE RabbitMQ
+	remote := "amqps://opensuse:opensuse@rabbit.opensuse.org"
+	key := "opensuse.openqa.#"
+
+	if len(os.Args) > 1 {
+		remote = os.Args[1]
+
+		if remote == "-h" || remote == "--help" {
+			printUsage()
+			os.Exit(0)
+		}
+
+		// Provide some nice shortcuts
+		if remote == "opensuse" || remote == "o3" || remote == "ooo" {
+			fmt.Fprintf(os.Stderr, "Using openSUSE RabbitMQ - See https://rabbit.opensuse.org/\n")
+			remote = "amqps://opensuse:opensuse@rabbit.opensuse.org"
+			key = "opensuse.openqa.#"
+		} else if remote == "suse" || remote == "osd" {
+			fmt.Fprintf(os.Stderr, "Using SUSE RabbitMQ - See https://rabbit.suse.de/\n")
+			remote = "amqps://suse:suse@rabbit.suse.de"
+			key = "suse.openqa.#"
+		}
+	}
+	if len(os.Args) > 2 {
+		key = os.Args[2]
+	}
+
+	// Establish connection to amqp
+	con, err := amqp.Dial(remote)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %s\n", err)
+		os.Exit(1)
+	}
+	defer con.Close()
+
+	// Establish channel and connect to queue.
+	/*
+	 * The most important parameter is "key", which defines the topic we are listening to.
+	 * The topic format is described as
+	   SCOPE.APPLICATION.OBJECT.ACTION
+	   ^     ^           ^      ^
+	   |     |           |      |
+	   |     |           |      +----- What happend with the object (verb in nonfinite form)
+	   |     |           +------------ What object was touched by the action
+	   |     +------------------------ In which application did the event occur
+	   +------------------------------ Was it an internal or external application
+
+	   The topic for openQA related messages on openqa.opensuse.org is e.g. 'suse.openqa.#'
+	   Wildcards: '*' stands for one arbitrary word, while '#' stands for multiple arbitrary words
+	*/
+	ch, err := con.Channel()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Channel error: %s\n", err)
+		os.Exit(1)
+	}
+	defer ch.Close()
+	q, err := ch.QueueDeclare("", false, false, false, false, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error declaring queue: %s\n", err)
+		os.Exit(1)
+	}
+	if err := ch.QueueBind(q.Name, key, "pubsub", false, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "Error binding to queue: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Receive messages from the established channel
+	msgs, err := ch.Consume(q.Name, "", true, false, false, false, nil)
+	go func() {
+		for d := range msgs {
+			fmt.Printf("%s %s\n", d.RoutingKey, d.Body)
+		}
+	}()
+	fmt.Fprintf(os.Stderr, "RabbitMQ connected: %s\n", rabbitRemote(remote))
+
+	// Terminate on termination signal
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		fmt.Fprintf(os.Stderr, "%s\n", sig)
+		done <- true
+	}()
+	<-done
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/grisu48/openqa-mon
 
 go 1.11
+
+require github.com/streadway/amqp v1.0.0 // indirect


### PR DESCRIPTION
Add `openqa-mq`, a simple utility to display the openQA related RabbitMQ
messages from openqa.opensuse.org and osd.