### PR TITLE
Add ability to quit program after jobs completed

### DIFF
--- a/cmd/openqa-mon/config.go
+++ b/cmd/openqa-mon/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Follow        bool     // follow jobs by default
 	Hierarchy     bool     // show hierarchy
 	HideStates    []string // hide the following job states
+	Quit          bool     // quit program, once all jobs are completed
 }
 
 func strBool(text string) (bool, error) {


### PR DESCRIPTION
Adds the `-e, --exit` parameter, which terminates openqa-mon when all jobs have completed (when in continuous mode).
The return code is 0 iif all jobs are passed or softfailing, otherwise it is non-zero.

Addresses https://github.com/grisu48/openqa-mon/issues/39.