### PR TITLE
Add version command and omit 'skipped' jobs

### DIFF
--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -10,6 +10,8 @@ import (
 	"github.com/streadway/amqp"
 )
 
+const VERSION = "1.0"
+
 func printUsage() {
 	fmt.Printf("Usage: %s [REMOTE] [KEY]\n", os.Args[0])
 	fmt.Println("  REMOTE - RabbitMQ address (e.g. amqps://opensuse:opensuse@rabbit.opensuse.org)")
@@ -37,6 +39,9 @@ func main() {
 
 		if remote == "-h" || remote == "--help" {
 			printUsage()
+			os.Exit(0)
+		} else if remote == "--version" {
+			fmt.Println("openqa-mq version " + VERSION)
 			os.Exit(0)
 		}
 

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -268,6 +268,9 @@ func parseProgramArgs() error {
 			if arg == "-h" || arg == "--help" {
 				printUsage()
 				os.Exit(0)
+			} else if arg == "--version" {
+				fmt.Println("openqa-revtui version " + VERSION)
+				os.Exit(0)
 			} else if arg == "-c" || arg == "--config" {
 				if i++; i >= n {
 					return fmt.Errorf("Missing argument: %s", "config file")

--- a/cmd/openqa-revtui/pc-review.toml
+++ b/cmd/openqa-revtui/pc-review.toml
@@ -1,0 +1,1 @@
+../../pc-review.toml


### PR DESCRIPTION
Add a `--version` command to all openqa-mon programs and omit
skipped jobs in job notifications.