### PR TITLE
Add script _review/run_screen_qac

### DIFF
--- a/_review/run_screen_qac
+++ b/_review/run_screen_qac
@@ -1,0 +1,23 @@
+#/bin/bash
+FILE=$(readlink -nf "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")
+DIR=$(dirname $FILE)
+DATE=$(date '+%G_%V')
+
+if [[ "$TERM" =~ ^screen ]]; then
+
+    pushd $DIR
+        screen -t notes $EDITOR ${DATE}_review_notes.txt
+
+        files="containers.toml opensuse-microos.toml publiccloud.toml"
+        for f in $files; do
+          screen -t $f openqa-revtui $_review_dir$f
+        done
+    popd
+    
+    screen -t bash
+    sleep 1; # avoid reusage of window 0
+
+else 
+    screen -S "$(basename $FILE)_${DATE}" $@ $FILE
+fi
+


### PR DESCRIPTION
This is a helper script to start screen with multiple windows using
`openqa-revtui` and the corresponding toml files for QAC.
The first windows will be a editor opend for notes. The name of the file
contains the year and the week number. The note file is places in the
same folder as the `run_screen_qac` script.

Usage:
```
ln -s ~/openqa-mon/_review/run_screen_qac ~/bin/openqa-revtui-qac
PATH=~/bin:$PATH
openqa-revtui-qac
```