### PR TITLE
Fix wrong line break in revtui

### DIFF
--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "0.3.2"
+const VERSION = "0.3.3"
 
 /* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
 type Group struct {

--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -522,7 +522,7 @@ func (tui *TUI) formatJobLine(job gopenqa.Job, width int) string {
 		cname := job.Name
 		nName := len(cname)
 		if width < 89+nName {
-			cname = cname[:width-89]
+			cname = cname[:width-90]
 		}
 		return fmt.Sprintf("%s%20s%s    %8d %s%-12s%s %40s | %s", c1, tStr, ANSI_RESET, job.ID, c2, state, ANSI_RESET+ANSI_WHITE, job.Link, cname)
 	} else if width > 60 {


### PR DESCRIPTION
When the terminal size makes revtui crop the line, there was one rouge
character. This introduced a unexpected line break causing the tui to
look silly.