### PR TITLE
openqa-revtui: Use empty line to separate job groups instead of header and tests

### DIFF
--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -334,7 +334,7 @@ func (tui *TUI) printJobsByGroup(width, height int) int {
 		jobs := groups[id]
 		statC := make(map[string]int, 0)
 		hidden := 0
-		lines = append(lines, fmt.Sprintf("===== %s ====================\n", grp.Name))
+		lines = append(lines, fmt.Sprintf("\n===== %s ====================", grp.Name))
 		for _, job := range jobs {
 			if !tui.hideJob(job) {
 				lines = append(lines, tui.formatJobLine(job, width))


### PR DESCRIPTION
Instead of:
```
===== openSUSE Leap 15.4 Incidents ====================

 2022-10-16-22:33:39     2809097 failed       https://openqa.opensuse.org/tests/2809097 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-cryptlvm@uefi-2G
 2022-10-16-22:59:40     2809096 failed       https://openqa.opensuse.org/tests/2809096 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-kde@64bit-2G
 2022-10-16-22:54:18     2809095 failed       https://openqa.opensuse.org/tests/2809095 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-gnome@64bit-2G
Total: 3, failed: 3
===== openSUSE Leap 15.4 Updates ====================

 2022-10-24-08:22:56     2830055 failed       https://openqa.opensuse.org/tests/2830055 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_textmode@64bit
 2022-10-24-07:45:45     2830054 user_cancelled https://openqa.opensuse.org/tests/2830054 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_gnome@64bit
 2022-10-24-06:41:59     2830053 failed       https://openqa.opensuse.org/tests/2830053 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_filesystem@64bit
Total: 20, failed: 10, passed: 5, softfailed: 4, user_cancelled: 1 (hidden: 9)
```

I'd like to have:
```
===== openSUSE Leap 15.4 Incidents ====================
 2022-10-16-22:33:39     2809097 failed       https://openqa.opensuse.org/tests/2809097 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-cryptlvm@uefi-2G
 2022-10-16-22:59:40     2809096 failed       https://openqa.opensuse.org/tests/2809096 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-kde@64bit-2G
 2022-10-16-22:54:18     2809095 failed       https://openqa.opensuse.org/tests/2809095 | opensuse-15.4-DVD-Incidents-x86_64-Build:17702:skelcd-openSUSE.1665947591-gnome@64bit-2G
Total: 3, failed: 3

===== openSUSE Leap 15.4 Updates ====================
 2022-10-24-08:22:56     2830055 failed       https://openqa.opensuse.org/tests/2830055 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_textmode@64bit
 2022-10-24-07:45:45     2830054 user_cancelled https://openqa.opensuse.org/tests/2830054 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_gnome@64bit
 2022-10-24-06:41:59     2830053 failed       https://openqa.opensuse.org/tests/2830053 | opensuse-15.4-DVD-Updates-x86_64-Build20221024-2-extra_tests_filesystem@64bit
Total: 20, failed: 10, passed: 5, softfailed: 4, user_cancelled: 1 (hidden: 9)
```