### PR TITLE
Add O3 and OSD job groups for the QE-Core squad

### DIFF
--- a/_review/qe-core-O3.toml
+++ b/_review/qe-core-O3.toml
@@ -1,0 +1,45 @@
+## Review template file for QE-Core job groups in O3
+# See: https://confluence.suse.com/display/qasle/Bugbusters+and+Review+Shifts#BugbustersandReviewShifts-Links
+
+Instance = "https://openqa.opensuse.org"                                              # openQA instance to query
+RabbitMQ = "amqps://opensuse:opensuse@rabbit.opensuse.org"                            # RabbitMQ instance to query
+RabbitMQTopic = "opensuse.openqa.job.done"                                            # RabbitMQ topic to query
+HideStatus = [ "scheduled", "passed", "softfailed", "running", "reviewed" ]           # Hide scheduled and passed jobs
+RefreshInterval = 60                             # Refresh from API once every minute
+MaxJobs = 20                                     # Max. job per group to display
+GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+
+# Leap 15.4
+
+[[Groups]]
+Name = "openSUSE Leap 15.4 Updates"
+Params = { groupid = "98", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "openSUSE Leap 15.4 Incidents"
+Params = { groupid = "97", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "openSUSE Leap 15.4 Backports"
+Params = { groupid = "99", build = "" }
+MaxLifetime = 86400
+
+# Leap 15.3
+
+[[Groups]]
+Name = "openSUSE Leap 15.3 Updates"
+Params = { groupid = "80", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "openSUSE Leap 15.3 Incidents"
+Params = { groupid = "81", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "openSUSE Leap 15.3 Backports"
+Params = { groupid = "84", build = "" }
+MaxLifetime = 86400
+

--- a/_review/qe-core-OSD.toml
+++ b/_review/qe-core-OSD.toml
@@ -1,0 +1,72 @@
+## Review template file for QE-Core job groups in OSD
+# See: https://confluence.suse.com/display/qasle/Bugbusters+and+Review+Shifts#BugbustersandReviewShifts-Links
+
+Instance = "https://openqa.suse.de"              # openQA instance to query
+RabbitMQ = "amqps://suse:suse@rabbit.suse.de"    # RabbitMQ instance to query
+RabbitMQTopic = "suse.openqa.job.done"           # RabbitMQ topic to query
+HideStatus = [ "scheduled", "passed", "softfailed", "running", "reviewed" ]           # Hide scheduled and passed jobs
+RefreshInterval = 60                             # Refresh from API once every minute
+MaxJobs = 20                                     # Max. job per group to display
+GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+
+# SLE Maintenance: Test Repo / Core Maintenance Updates
+
+[[Groups]]
+Name = "SLE Maintenance: Test Repo / Core Maintenance Updates"
+Params = { groupid = "414", build = "" }
+MaxLifetime = 86400
+
+# Maintenance Single Incidents
+
+[[Groups]]
+Name = "Maintenance: SLE 15 SP4 Incidents"
+Params = { groupid = "439", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 15 SP3 Incidents"
+Params = { groupid = "367", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 15 SP2 Incidents"
+Params = { groupid = "306", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 15 SP1 Incidents"
+Params = { groupid = "233", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 15 GA Incidents"
+Params = { groupid = "159", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 12 SP5 Incidents"
+Params = { groupid = "282", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 12 SP4 Incidents"
+Params = { groupid = "215", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 12 SP3 Incidents"
+Params = { groupid = "106", build = "" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Maintenance: SLE 12 SP2 Incidents"
+Params = { groupid = "53", build = "" }
+MaxLifetime = 86400
+
+# Functional
+
+[[Groups]]
+Name = "SLE 15 - Functional"
+Params = { groupid = "110", build = "" }
+MaxLifetime = 86400
+


### PR DESCRIPTION
This adds job groups for QE-Core. Those can be found in [Confluence](https://confluence.suse.com/display/qasle/Bugbusters+and+Review+Shifts#BugbustersandReviewShifts-Links).