### PR TITLE
Add multiple key handlings to openqa-mq

### DIFF
--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -10,26 +10,28 @@ import (
 	"github.com/streadway/amqp"
 )
 
-const VERSION = "1.1"
+const VERSION = "1.2"
 
 type Config struct {
-	Remote   string // Remote address
-	Key      string // Key or "topic"
-	Username string
-	Password string
-	Insecure bool
+	Remote     string   // Remote address
+	Keys       []string // Keys or "topics"
+	Username   string
+	Password   string
+	PrintTopic bool // Print topic
+	Insecure   bool
+	Verbose    bool
 }
 
 func (cf *Config) SetOSD() {
 	cf.Remote = "amqps://suse:suse@rabbit.suse.de"
-	cf.Key = "suse.openqa.#"
+	cf.Keys = []string{"suse.openqa.#"}
 	cf.Username = "suse"
 	cf.Password = "suse"
 	cf.Insecure = false
 }
 func (cf *Config) SetO3() {
 	cf.Remote = "amqps://opensuse:opensuse@rabbit.opensuse.org"
-	cf.Key = "opensuse.openqa.#"
+	cf.Keys = []string{"opensuse.openqa.#"}
 	cf.Username = "opensuse"
 	cf.Password = "opensuse"
 	cf.Insecure = false
@@ -40,7 +42,7 @@ var config Config
 func printUsage() {
 	fmt.Printf("Usage: %s [OPTIONS] [REMOTE] [KEY] [USERNAME] [PASSWORD]\n", os.Args[0])
 	fmt.Println("  REMOTE            Define RabbitMQ address (e.g. amqps://opensuse:opensuse@rabbit.opensuse.org)")
-	fmt.Println("  KEY               Queue key to bind to (e.g. opensuse.openqa.# for all openQA messages)")
+	fmt.Println("  KEY               Key to bind to (e.g. opensuse.openqa.# for all openQA messages)")
 	fmt.Println("  USERNAME          Username to login to the server")
 	fmt.Println("  PASSWORD          Password to login to the server")
 	fmt.Println("")
@@ -48,13 +50,16 @@ func printUsage() {
 	fmt.Println("If remote is a amqp:// or amqps:// URI, username and password will be ignored")
 	fmt.Println("OPTIONS")
 	fmt.Println("  -r HOST           Set remote endpoint of address. Identical to REMOTE")
-	fmt.Println("  -k KEY            Set queue key to bind to. Identical to KEY")
+	fmt.Println("  -k KEY            Add key to bind to. Multiple parameters are allowed. Identical to KEY")
 	fmt.Println("  -u USER           Set username for the amqp connection. Identical to USERNAME")
 	fmt.Println("  -p PASS           Set password for the amqpconnection. Identical to PASSWORD")
 	fmt.Println("  -i                Use insecure (unencrypted) connection")
+	fmt.Println("  -n, --no-topic    Don't print the topic")
+	fmt.Println("  -v, --verbose     Verbose mode")
+	fmt.Println("  -version          Print program version")
 	fmt.Println("")
 	fmt.Println("  --osd             Use settings for openqa.suse.de")
-	fmt.Println("  --o3              Use settings for openqa.opensuse.org (default)")
+	fmt.Println("  --o3,--ooo        Use settings for openqa.opensuse.org (default)")
 }
 
 // Returns the remote host from a RabbitMQ URL
@@ -69,6 +74,7 @@ func rabbitRemote(remote string) string {
 func parseProgramArguments() error {
 	args := os.Args[1:]
 	argcount := 0 // Keep counter for distinguishing between remote and key
+	keys := make([]string, 0)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "" {
@@ -93,7 +99,7 @@ func parseProgramArguments() error {
 					return fmt.Errorf("missing key argument")
 				}
 				i++
-				config.Key = args[i]
+				keys = append(keys, args[i])
 			} else if arg == "-u" {
 				if i >= len(args)-1 {
 					return fmt.Errorf("missing username argument")
@@ -112,6 +118,10 @@ func parseProgramArguments() error {
 				config.SetOSD()
 			} else if arg == "--o3" || arg == "--ooo" {
 				config.SetO3()
+			} else if arg == "-v" || arg == "--verbose" {
+				config.Verbose = true
+			} else if arg == "-n" || arg == "--no-topic" || arg == "--notopic" {
+				config.PrintTopic = false
 			} else {
 				return fmt.Errorf("invalid argument: %s", arg)
 			}
@@ -119,7 +129,7 @@ func parseProgramArguments() error {
 			if argcount == 0 {
 				config.Remote = arg
 			} else if argcount == 1 {
-				config.Password = arg
+				keys = append(keys, arg)
 			} else if argcount == 2 {
 				config.Username = arg
 			} else if argcount == 3 {
@@ -136,6 +146,11 @@ func parseProgramArguments() error {
 		config.SetO3()
 	} else if config.Remote == "suse" || config.Remote == "osd" {
 		config.SetOSD()
+	}
+
+	// Apply custom keys
+	if len(keys) > 0 {
+		config.Keys = keys
 	}
 
 	return nil
@@ -156,6 +171,9 @@ func assembleRemote() string {
 }
 
 func main() {
+	config.Keys = make([]string, 0)
+	config.Verbose = false
+	config.PrintTopic = true
 	config.SetO3() // Use openqa.opensuse.org by default
 
 	if err := parseProgramArguments(); err != nil {
@@ -164,6 +182,9 @@ func main() {
 	}
 
 	remote := assembleRemote()
+	if config.Verbose {
+		fmt.Printf("Connecting to %s ... \n", config.Remote)
+	}
 
 	// Establish connection to amqp
 	con, err := amqp.Dial(remote)
@@ -188,30 +209,61 @@ func main() {
 	   The topic for openQA related messages on openqa.opensuse.org is e.g. 'suse.openqa.#'
 	   Wildcards: '*' stands for one arbitrary word, while '#' stands for multiple arbitrary words
 	*/
+
+	if config.Verbose {
+		fmt.Printf("Opening channel ... \n")
+	}
 	ch, err := con.Channel()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Channel error: %s\n", err)
 		os.Exit(1)
 	}
 	defer ch.Close()
-	q, err := ch.QueueDeclare("", false, false, false, false, nil)
+	// Produce a new queue and bind it to the desired routing keys. We set the auto-delete flag to avoid spamming the server
+	if config.Verbose {
+		fmt.Printf("Declare a new exclusive queue ... \n")
+	}
+	q, err := ch.QueueDeclare("", false, true, true, false, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error declaring queue: %s\n", err)
 		os.Exit(1)
 	}
-	if err := ch.QueueBind(q.Name, config.Key, "pubsub", false, nil); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding to queue: %s\n", err)
-		os.Exit(1)
+	if config.Verbose {
+		fmt.Printf("  Queue: '%s' \n", q.Name)
+	}
+	for _, key := range config.Keys {
+		if config.Verbose {
+			fmt.Printf("  Binding to key '%s' ... \n", key)
+		}
+		if err := ch.QueueBind(q.Name, key, "pubsub", false, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding to queue: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Receive messages from the established channel
+	if config.Verbose {
+		fmt.Printf("Starting receive ... \n")
+	}
 	msgs, err := ch.Consume(q.Name, "", true, false, false, false, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "recveive error: %s\n", err)
+		os.Exit(1)
+	}
 	go func() {
 		for d := range msgs {
-			fmt.Printf("%s %s\n", d.RoutingKey, d.Body)
+			if config.PrintTopic {
+				fmt.Printf("%s %s\n", d.RoutingKey, d.Body)
+			} else {
+				fmt.Printf("%s\n", d.Body)
+			}
 		}
 	}()
-	fmt.Fprintf(os.Stderr, "RabbitMQ connected: %s\n", rabbitRemote(remote))
+	if config.Verbose {
+		fmt.Printf("Connection established. Waiting for messages.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "RabbitMQ connected: %s\n", rabbitRemote(remote))
+	}
 
 	// Terminate on termination signal
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
This commit adds the feature to add multiple keys via multiple -k parameters to openqa-mq. In addition the queue handling is improved (use exclusive queues) and the `-n` or `--no-topic` parameter is introduced.

This commit also increases the openqa-mq version to 1.2