### PR TITLE
Improve the screen behaviour of revtui

### DIFF
--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -350,7 +350,6 @@ func parseProgramArgs() error {
 }
 
 func printUsage() {
-	// TODO: Write this
 	fmt.Printf("Usage: %s [OPTIONS] [FLAVORS]\n", os.Args[0])
 	fmt.Println("")
 	fmt.Println("OPTIONS")

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "0.3.4"
+const VERSION = "0.4.0"
 
 /* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
 type Group struct {
@@ -559,6 +559,7 @@ func tui_main(tui *TUI, instance gopenqa.Instance) error {
 	}
 	knownJobs = jobs
 	tui.Model.Apply(knownJobs)
+	fmt.Println("Initial fetching completed. Entering main loop ... ")
 	tui.Start()
 	tui.Update()
 

--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -577,6 +577,13 @@ func (tui *TUI) formatJobLine(job gopenqa.Job, width int) string {
 		}
 	}
 
+	// Crop the state field, if necessary
+	if state == "timeout_exceeded" {
+		state = "timeout"
+	} else if len(state) > 12 {
+		state = state[0:12]
+	}
+
 	// Full status line requires 89 characters (20+4+8+1+12+1+40+3) plus name
 	if width > 90 {
 		// Crop the name, if necessary


### PR DESCRIPTION
Rewrite the screen behaviour of revtui. Now openqa-revtui will build always the full screen and perform scrolling operations on it. This makes the code more readable and fixes some common issues with the revtui screen behaviour, especially when scrolling in grouping mode.

It also contains a commit for fixing a too large state field (e.g. `timeout_exceeded`)