### PR TITLE
Upgrade to gopenqa 0.7.1 and align version number

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "0.8.2"
+const VERSION = "1.0.1"
 
 var config Config
 var tui TUI

--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -10,7 +10,7 @@ import (
 	"github.com/streadway/amqp"
 )
 
-const VERSION = "1.2"
+const VERSION = "1.0.1"
 
 type Config struct {
 	Remote     string   // Remote address

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "0.6.0"
+const VERSION = "1.0.1"
 
 /* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
 type Group struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.2.1
-	github.com/grisu48/gopenqa v0.7.0
+	github.com/grisu48/gopenqa v0.7.1
 	github.com/streadway/amqp v1.0.0
 	golang.org/x/crypto v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/grisu48/gopenqa v0.7.0 h1:9wCdJHGiz1/1tXUupW+r/myeFCDBGF9NojOCjhEghlQ=
-github.com/grisu48/gopenqa v0.7.0/go.mod h1:D7EFTPhtzNvnHnDol9UoPCFmnzOiLBVa1tOOYqJDgGo=
+github.com/grisu48/gopenqa v0.7.1 h1:XhmsWY93WjqdnXmdDjjHTFdfLjQwz7kApviDM9lX27U=
+github.com/grisu48/gopenqa v0.7.1/go.mod h1:D7EFTPhtzNvnHnDol9UoPCFmnzOiLBVa1tOOYqJDgGo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=


### PR DESCRIPTION
Update to gopenqa 0.7.1 for fixing the missing links in GetFollowJobs and unify the version number across openqa-mon, openqa-mq and openqa-revtui.