### PR TITLE
Revtui refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ openqa-mq: cmd/openqa-mq/openqa-mq.go
 	go build $(GOARGS) -o $@ $^
 openqa-mq-static: cmd/openqa-mq/openqa-mq.go
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mq $^
-openqa-revtui: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go
+openqa-revtui: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go
 	go build $(GOARGS) -o $@ $^
-openqa-revtui-static: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go
+openqa-revtui-static: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-revtui $^
 
 requirements:

--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "1.1.0"
+const VERSION = "1.2.0"
 
 var config Config
 var tui TUI

--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -10,7 +10,7 @@ import (
 	"github.com/streadway/amqp"
 )
 
-const VERSION = "1.1.0"
+const VERSION = "1.2.0"
 
 type Config struct {
 	Remote     string   // Remote address

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "1.1.0"
+const VERSION = "1.2.0"
 
 /* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
 type Group struct {

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -576,7 +576,8 @@ func tui_main(tui *TUI, instance *gopenqa.Instance) error {
 			if len(jobs) == 0 {
 				tui.SetStatus("No visible jobs")
 			} else if len(jobs) > 10 && key == 'o' {
-				tui.SetStatus("Refusing to open more than 10 job links. Use 'O' to override")
+				status := fmt.Sprintf("Refuse to open %d (>10) job links. Use 'O' to override", len(jobs))
+				tui.SetTemporaryStatus(status, 5)
 			} else {
 				if err := browserJobs(jobs); err != nil {
 					tui.SetStatus(fmt.Sprintf("error: %s", err))

--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -159,6 +159,23 @@ func (tui *TUI) SetStatus(status string) {
 	tui.status = status
 }
 
+func (tui *TUI) SetTemporaryStatus(status string, duration int) {
+	tui.Model.mutex.Lock()
+	old := tui.status
+	tui.status = status
+	tui.Model.mutex.Unlock()
+	tui.Update()
+
+	// Reset status text after waiting for duration. But only, if the status text has not been altered in the meantime
+	go func(old, status string, duration int) {
+		time.Sleep(time.Duration(duration) * time.Second)
+		if tui.status == status {
+			tui.status = old
+			tui.Update()
+		}
+	}(old, status, duration)
+}
+
 func (tui *TUI) Status() string {
 	return tui.status
 }

--- a/cmd/openqa-revtui/utils.go
+++ b/cmd/openqa-revtui/utils.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+)
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func homeDir() string {
+	usr, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	return usr.HomeDir
+}
+
+// Split a NAME=VALUE string
+func splitNV(v string) (string, string, error) {
+	i := strings.Index(v, "=")
+	if i < 0 {
+		return "", "", fmt.Errorf("no separator")
+	}
+	return v[:i], v[i+1:], nil
+}


### PR DESCRIPTION
Adding three `openqa-revtui` improvements:

* Refactor some utility functions and follow style suggestions from `go fmt`
* Add temporary status fields and use it for the error message when opening links in the browser
* Bump version to 1.2.0

I also did a modules check - all go modules are up-to-date.