### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "1.2.0"
+const VERSION = "1.2.1"
 
 var config Config
 var tui TUI

--- a/cmd/openqa-mq/openqa-mq.go
+++ b/cmd/openqa-mq/openqa-mq.go
@@ -10,7 +10,7 @@ import (
 	"github.com/streadway/amqp"
 )
 
-const VERSION = "1.2.0"
+const VERSION = "1.2.1"
 
 type Config struct {
 	Remote     string   // Remote address

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grisu48/gopenqa"
 )
 
-const VERSION = "1.2.0"
+const VERSION = "1.2.1"
 
 /* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
 type Group struct {


### PR DESCRIPTION
Reparation to a new release after updating gopenqa.

* https://github.com/grisu48/gopenqa/releases/tag/v0.7.3