### PR TITLE
Make openqa-mon testable again 😸

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -512,8 +512,8 @@ func SetStatus() {
 	}
 }
 
-func parseProgramArguments() error {
-	args, err := expandArguments(os.Args[1:])
+func parseProgramArguments(cliargs []string) error {
+	args, err := expandArguments(cliargs[1:])
 	if err != nil {
 		return err
 	}
@@ -690,7 +690,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := parseProgramArguments(); err != nil {
+	if err := parseProgramArguments(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/cmd/openqa-mon/openqa-mon_test.go
+++ b/cmd/openqa-mon/openqa-mon_test.go
@@ -24,9 +24,13 @@ func TestAdd2JobsToSameRemote(t *testing.T) {
 	if err != nil {
 		t.Error("Error parsing command line:", err)
 	}
-	expected := []int64{5701879, 5701880}
-	if !reflect.DeepEqual(remotes[0].Jobs, expected) {
-		t.Error("Expected,", expected, "jobs, got", remotes[0].Jobs)
+	expected_jobs := []int64{5701879, 5701880}
+	if !reflect.DeepEqual(remotes[0].Jobs, expected_jobs) {
+		t.Error("Expected,", expected_jobs, "jobs, got", remotes[0].Jobs)
+	}
+	expected_URI := "https://openqa.opensuse.org"
+	if remotes[0].URI != expected_URI {
+		t.Error("Expected remote URI=", expected_URI, ",got", remotes[0].URI)
 	}
 }
 

--- a/cmd/openqa-mon/openqa-mon_test.go
+++ b/cmd/openqa-mon/openqa-mon_test.go
@@ -1,17 +1,74 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-func TestAddJobs(t *testing.T) {
-    args_t := []string{"https://openqa.opensuse.org", "--jobs", "5701879,5701880"}
-    remotes_t := make([]Remote, 0)
-    j := []int{1, 2, 3}
-    r1 := Remote{"http://openqa.opensuse.org", j}
-    remotes_t = append(remotes_t, r1)
-    parseArgs(args_t, &remotes_t)
-    actual_len := len(remotes_t[0].Jobs)
-    expected_jobs := 3
-    if (actual_len != expected_jobs) {
-      t.Error("Expected", expected_jobs, "got ", actual_len)
-    }
+func TestAddRemoteFromCLI(t *testing.T) {
+	remotes = make([]Remote, 0)
+	testargs := []string{"openqa-mon", "https://openqa.opensuse.org/5701879", "https://openqa.opensuse.org/5701880"}
+	err := parseProgramArguments(testargs)
+	if err != nil {
+		t.Error("Error parsing command line:", err)
+	}
+	if len(remotes) != 2 {
+		t.Error("Expected 2 remotes, got ", len(remotes))
+	}
+}
+
+func TestAdd2JobsToSameRemote(t *testing.T) {
+	remotes = make([]Remote, 0)
+	testargs := []string{"openqa-mon", "https://openqa.opensuse.org/t5701879+1"}
+	err := parseProgramArguments(testargs)
+	if err != nil {
+		t.Error("Error parsing command line:", err)
+	}
+	expected := []int64{5701879, 5701880}
+	if !reflect.DeepEqual(remotes[0].Jobs, expected) {
+		t.Error("Expected,", expected, "jobs, got", remotes[0].Jobs)
+	}
+}
+
+func TestRemotesMultipleJobs(t *testing.T) {
+	remotes = make([]Remote, 0)
+	testargs := []string{"openqa-mon", "https://openqa.suse.de/t100..150", "https://openqa.opensuse.org/t19999+1"}
+	err := parseProgramArguments(testargs)
+	if err != nil {
+		t.Error("Error parsing command line:", err)
+	}
+	if len(remotes) != 2 {
+		t.Error("Expected 2 remotes, got ", len(remotes))
+	}
+	totalJobs := len(remotes[0].Jobs) + len(remotes[1].Jobs)
+	if totalJobs != 53 {
+		t.Error("Expected 53 jobs, got", totalJobs)
+	}
+}
+
+func TestShouldGiveError(t *testing.T) {
+	tests := []struct {
+		input       []string
+		expectedmsg string
+	}{
+		{
+			[]string{"openqa-mon", "--jobs", "foo,bar,baz"},
+			"jobs need to be defined after a remote instance",
+		},
+		{
+			[]string{"openqa-mon", "https://openqa.opensuse.org", "--jobs", "tfoobar"},
+			"illegal job identifier: tfoobar",
+		},
+		{
+			[]string{"openqa-mon", "https://openqa.opensuse.org", "--jobs", "-31415"},
+			"missing job IDs",
+		},
+	}
+	for _, tc := range tests {
+		remotes = make([]Remote, 0)
+		err := parseProgramArguments(tc.input)
+		if err.Error() != tc.expectedmsg {
+			t.Error("Expected", tc.expectedmsg, "got:", err)
+		}
+	}
 }


### PR DESCRIPTION
partially tackling #28 , added some unit tests as a starting point for command line parsing validation

