### PR TITLE
Refactor config.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ openqa-mq: cmd/openqa-mq/openqa-mq.go
 	go build $(GOARGS) -o $@ $^
 openqa-mq-static: cmd/openqa-mq/openqa-mq.go
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mq $^
-openqa-revtui: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go
+openqa-revtui: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go cmd/openqa-revtui/config.go
 	go build $(GOARGS) -o $@ $^
-openqa-revtui-static: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go
+openqa-revtui-static: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go cmd/openqa-revtui/config.go
 	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-revtui $^
 
 requirements:

--- a/cmd/openqa-revtui/config.go
+++ b/cmd/openqa-revtui/config.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+/* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
+type Group struct {
+	Name        string
+	Params      map[string]string // Default parameters for query
+	MaxLifetime int64             // Ignore entries that are older than this value in seconds from now
+}
+
+/* Program configuration parameters */
+type Config struct {
+	Instance        string            // Instance URL to be used
+	RabbitMQ        string            // RabbitMQ url to be used
+	RabbitMQTopic   string            // Topic to subscribe to
+	DefaultParams   map[string]string // Default parameters
+	HideStatus      []string          // Status to hide
+	Notify          bool              // Notify on job status change
+	RefreshInterval int64             // Periodic refresh delay in seconds
+	Groups          []Group           // Groups that will be monitord
+	MaxJobs         int               // Maximum number of jobs per group to consider
+	GroupBy         string            // Display group mode: "none", "groups"
+}
+
+var cf Config
+
+func (cf *Config) LoadToml(filename string) error {
+	if _, err := toml.DecodeFile(filename, cf); err != nil {
+		return err
+	}
+	// Apply default parameters to group after loading
+	for i, group := range cf.Groups {
+		for k, v := range cf.DefaultParams {
+			if _, exists := group.Params[k]; exists {
+				continue
+			} else {
+				group.Params[k] = v
+			}
+		}
+		// Apply parameter macros
+		for k, v := range group.Params {
+			param := parseParameter(v)
+			if strings.Contains(param, "%") {
+				return fmt.Errorf("invalid parameter macro in %s", param)
+			}
+			group.Params[k] = param
+		}
+		cf.Groups[i] = group
+	}
+	return nil
+}
+
+/* Create configuration instance and set default vaules */
+func CreateConfig() Config {
+	var cf Config
+	cf.Instance = "https://openqa.opensuse.org"
+	cf.RabbitMQ = "amqps://opensuse:opensuse@rabbit.opensuse.org"
+	cf.RabbitMQTopic = "opensuse.openqa.job.done"
+	cf.HideStatus = make([]string, 0)
+	cf.Notify = true
+	cf.RefreshInterval = 30
+	cf.DefaultParams = make(map[string]string, 0)
+	cf.Groups = make([]Group, 0)
+	cf.MaxJobs = 20
+	return cf
+}

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -7,76 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/grisu48/gopenqa"
 	"github.com/grisu48/openqa-mon/internal"
 )
 
-/* Group is a single configurable monitoring unit. A group contains all parameters that will be queried from openQA */
-type Group struct {
-	Name        string
-	Params      map[string]string // Default parameters for query
-	MaxLifetime int64             // Ignore entries that are older than this value in seconds from now
-}
-
-/* Program configuration parameters */
-type Config struct {
-	Instance        string            // Instance URL to be used
-	RabbitMQ        string            // RabbitMQ url to be used
-	RabbitMQTopic   string            // Topic to subscribe to
-	DefaultParams   map[string]string // Default parameters
-	HideStatus      []string          // Status to hide
-	Notify          bool              // Notify on job status change
-	RefreshInterval int64             // Periodic refresh delay in seconds
-	Groups          []Group           // Groups that will be monitord
-	MaxJobs         int               // Maximum number of jobs per group to consider
-	GroupBy         string            // Display group mode: "none", "groups"
-}
-
-var cf Config
 var knownJobs []gopenqa.Job
 var updatedRefresh bool
-
-func (cf *Config) LoadToml(filename string) error {
-	if _, err := toml.DecodeFile(filename, cf); err != nil {
-		return err
-	}
-	// Apply default parameters to group after loading
-	for i, group := range cf.Groups {
-		for k, v := range cf.DefaultParams {
-			if _, exists := group.Params[k]; exists {
-				continue
-			} else {
-				group.Params[k] = v
-			}
-		}
-		// Apply parameter macros
-		for k, v := range group.Params {
-			param := parseParameter(v)
-			if strings.Contains(param, "%") {
-				return fmt.Errorf("invalid parameter macro in %s", param)
-			}
-			group.Params[k] = param
-		}
-		cf.Groups[i] = group
-	}
-	return nil
-}
-
-/* Create configuration instance and set default vaules */
-func CreateConfig() Config {
-	var cf Config
-	cf.Instance = "https://openqa.opensuse.org"
-	cf.RabbitMQ = "amqps://opensuse:opensuse@rabbit.opensuse.org"
-	cf.RabbitMQTopic = "opensuse.openqa.job.done"
-	cf.HideStatus = make([]string, 0)
-	cf.Notify = true
-	cf.RefreshInterval = 30
-	cf.DefaultParams = make(map[string]string, 0)
-	cf.Groups = make([]Group, 0)
-	cf.MaxJobs = 20
-	return cf
-}
 
 func getKnownJob(id int64) (gopenqa.Job, bool) {
 	for _, j := range knownJobs {


### PR DESCRIPTION
Move the configuration structs and routines to their own go file.

This PR is a preparation step for introducing a feature to limit the number of jobs requested per http request.