### PR TITLE
Limit number of jobs per http request

### DIFF
--- a/_review/opensuse-containers.toml
+++ b/_review/opensuse-containers.toml
@@ -8,6 +8,7 @@ RefreshInterval = 60                                            # Refresh from A
 MaxJobs = 20                                                    # Max. job per group to display
 GroupBy = "groups"                                              # Group by defined groups ("none" or "groups")
 DefaultParams = { distri="opensuse", version = "Tumbleweed" }   # Set of default parameters
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## Define job groups
 

--- a/_review/opensuse-microos.toml
+++ b/_review/opensuse-microos.toml
@@ -8,6 +8,7 @@ RefreshInterval = 60                                            # Refresh from A
 MaxJobs = 20                                                    # Max. job per group to display
 GroupBy = "groups"                                              # Group by defined groups ("none" or "groups")
 DefaultParams = { distri="microos", version = "Tumbleweed" }    # Set of default parameters
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## Define job groups
 [[Groups]]

--- a/_review/opensuse-tumbleweed.toml
+++ b/_review/opensuse-tumbleweed.toml
@@ -8,6 +8,7 @@ RefreshInterval = 60                                            # Refresh from A
 MaxJobs = 20                                                    # Max. job per group to display
 GroupBy = "groups"                                              # Group by defined groups ("none" or "groups")
 DefaultParams = { distri="opensuse", version = "Tumbleweed" }   # Set of default parameters
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## Define job groups
 

--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -7,6 +7,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## BCI and Base images #########################################################
 

--- a/_review/qe-core-O3.toml
+++ b/_review/qe-core-O3.toml
@@ -8,6 +8,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                                            # Refresh from API once every minute
 MaxJobs = 20                                                    # Max. job per group to display
 GroupBy = "groups"                                              # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 # Tumbleweed
 

--- a/_review/qe-core-OSD.toml
+++ b/_review/qe-core-OSD.toml
@@ -8,6 +8,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 # SLE Maintenance: Test Repo / Core Maintenance Updates
 

--- a/_review/qec-bci.toml
+++ b/_review/qec-bci.toml
@@ -7,6 +7,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## BCI and Base images
 [[Groups]]

--- a/_review/qec-containers.toml
+++ b/_review/qec-containers.toml
@@ -7,6 +7,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 
 ## Maintenance updates

--- a/_review/qec-minimalvm.toml
+++ b/_review/qec-minimalvm.toml
@@ -7,6 +7,7 @@ HideStatus = ["scheduled", "passed", "softfailed", "cancelled", "skipped", "runn
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 ## Maintenance updates
 [[Groups]]

--- a/_review/qec-publiccloud.toml
+++ b/_review/qec-publiccloud.toml
@@ -9,6 +9,7 @@ RefreshInterval = 60                             # Refresh from API once every m
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
 DefaultParams = { distri = "sle" }               # Set of default parameters
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 
 ## Maintenance updates

--- a/_review/qec-sle-micro.toml
+++ b/_review/qec-sle-micro.toml
@@ -7,6 +7,7 @@ HideStatus = [ "scheduled", "passed", "softfailed", "running", "reviewed", "user
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 
 ## SLE Micro image updates

--- a/_review/qec-wsl.toml
+++ b/_review/qec-wsl.toml
@@ -7,6 +7,7 @@ HideStatus = [ "scheduled", "passed", "softfailed", "running", "reviewed", "user
 RefreshInterval = 60                             # Refresh from API once every minute
 MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100                                           # Query up to 100 jobs per http request
 
 
 ## WSL builds

--- a/cmd/openqa-revtui/config.go
+++ b/cmd/openqa-revtui/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Groups          []Group           // Groups that will be monitord
 	MaxJobs         int               // Maximum number of jobs per group to consider
 	GroupBy         string            // Display group mode: "none", "groups"
+	RequestJobLimit int               // Maximum number of jobs in a single request
 }
 
 var cf Config
@@ -68,5 +69,6 @@ func CreateConfig() Config {
 	cf.DefaultParams = make(map[string]string, 0)
 	cf.Groups = make([]Group, 0)
 	cf.MaxJobs = 20
+	cf.RequestJobLimit = 100
 	return cf
 }

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -231,7 +231,7 @@ func refreshJobs(tui *TUI, instance *gopenqa.Instance) error {
 	for _, job := range oldJobs {
 		ids = append(ids, job.ID)
 	}
-	jobs, err := instance.GetJobsFollow(ids)
+	jobs, err := fetchJobsFollow(ids, instance)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a configuration setting to limit the number of jobs requested per http request. The default value is 100.

This fixes https://github.com/os-autoinst/openqa-mon/issues/155