### PR TITLE
Improve pagination for openqa-mon

### DIFF
--- a/cmd/openqa-mon/tui.go
+++ b/cmd/openqa-mon/tui.go
@@ -269,22 +269,36 @@ func (tui *TUI) SetHideStates(enabled bool) {
 	tui.Update()
 }
 
+func (tui *TUI) UpdateHeader() {
+	tui.header = fmt.Sprintf("openqa-mon v%s - Monitoring %s - Page %d/%d", internal.VERSION, tui.remotes, 1+tui.currentPage, tui.totalPages)
+}
+
+func (tui *TUI) FirstPage() {
+	tui.Model.mutex.Lock()
+	defer tui.Model.mutex.Unlock()
+	tui.currentPage = 0
+	tui.UpdateHeader()
+}
+
+func (tui *TUI) LastPage() {
+	tui.Model.mutex.Lock()
+	defer tui.Model.mutex.Unlock()
+	tui.currentPage = max(0, tui.totalPages-1)
+	tui.UpdateHeader()
+}
+
 func (tui *TUI) NextPage() {
 	tui.Model.mutex.Lock()
 	defer tui.Model.mutex.Unlock()
-	if tui.currentPage < tui.totalPages-1 {
-		tui.currentPage++
-		tui.header = fmt.Sprintf("openqa-mon v%s - Monitoring %s - Page %d/%d", internal.VERSION, tui.remotes, 1+tui.currentPage, tui.totalPages)
-	}
+	tui.currentPage = min(tui.totalPages-1, tui.currentPage+1)
+	tui.UpdateHeader()
 }
 
 func (tui *TUI) PrevPage() {
 	tui.Model.mutex.Lock()
 	defer tui.Model.mutex.Unlock()
-	if tui.currentPage > 0 {
-		tui.currentPage--
-		tui.header = fmt.Sprintf("openqa-mon v%s - Monitoring %s - Page %d/%d", internal.VERSION, tui.remotes, 1+tui.currentPage, tui.totalPages)
-	}
+	tui.currentPage = max(0, tui.currentPage-1)
+	tui.UpdateHeader()
 }
 
 func (tui *TUI) DoHideStates() bool {

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -291,7 +291,8 @@ func tui_main(tui *TUI, instance *gopenqa.Instance) error {
 	refreshing := false
 	tui.Keypress = func(key byte) {
 		// Input handling
-		if key == 'r' {
+		switch key {
+		case 'r':
 			if !refreshing {
 				refreshing = true
 				go func() {
@@ -302,22 +303,22 @@ func tui_main(tui *TUI, instance *gopenqa.Instance) error {
 				}()
 				tui.Update()
 			}
-		} else if key == 'u' {
+		case 'u':
 			tui.Update()
-		} else if key == 'q' {
+		case 'q':
 			tui.done <- true
-		} else if key == 'h' {
+		case 'h':
 			tui.SetHide(!tui.Hide())
 			tui.Model.MoveHome()
 			tui.Update()
-		} else if key == 'm' {
+		case 'm':
 			tui.SetShowTracker(!tui.showTracker)
 			tui.Update()
-		} else if key == 's' {
+		case 's':
 			// Shift through the sorting mechanism
 			tui.SetSorting((tui.Sorting() + 1) % 2)
 			tui.Update()
-		} else if key == 'o' || key == 'O' {
+		case 'o', 'O':
 			// Note: 'o' has a failsafe to not open more than 10 links. 'O' overrides this failsafe
 			jobs := tui.GetVisibleJobs()
 			if len(jobs) == 0 {
@@ -333,7 +334,7 @@ func tui_main(tui *TUI, instance *gopenqa.Instance) error {
 				}
 			}
 			tui.Update()
-		} else {
+		default:
 			tui.Update()
 		}
 	}

--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -204,28 +204,32 @@ func (tui *TUI) readInput() {
 		p[2], p[1], p[0] = p[1], p[0], k
 
 		// Catch special keys
-		if p[1] == 91 && k == 65 { // Arrow up
-			if tui.Model.offset > 0 {
-				tui.Model.offset--
-				tui.Update()
+		if p[2] == 27 && p[1] == 91 {
+			switch k {
+			case 65: // arrow up
+				if tui.Model.offset > 0 {
+					tui.Model.offset--
+					tui.Update()
+				}
+
+			case 66: // arrow down
+				max := max(0, (tui.Model.printLines - tui.screensize))
+				if tui.Model.offset < max {
+					tui.Model.offset++
+					tui.Update()
+				}
+			case 72: // home
+				tui.Model.offset = 0
+			case 70: // end
+				tui.Model.offset = max(0, (tui.Model.printLines - tui.screensize))
+			case 53: // page up
+				// Always leave one line overlap for better orientation
+				tui.Model.offset = max(0, tui.Model.offset-tui.screensize+1)
+			case 54: // page down
+				max := max(0, (tui.Model.printLines - tui.screensize))
+				// Always leave one line overlap for better orientation
+				tui.Model.offset = min(max, tui.Model.offset+tui.screensize-1)
 			}
-		} else if p[1] == 91 && k == 66 { // Arrow down
-			max := max(0, (tui.Model.printLines - tui.screensize))
-			if tui.Model.offset < max {
-				tui.Model.offset++
-				tui.Update()
-			}
-		} else if p[2] == 27 && p[1] == 91 && p[0] == 72 { // home
-			tui.Model.offset = 0
-		} else if p[2] == 27 && p[1] == 91 && p[0] == 70 { // end
-			tui.Model.offset = max(0, (tui.Model.printLines - tui.screensize))
-		} else if p[2] == 27 && p[1] == 91 && p[0] == 53 { // page up
-			// Always leave one line overlap for better orientation
-			tui.Model.offset = max(0, tui.Model.offset-tui.screensize+1)
-		} else if p[2] == 27 && p[1] == 91 && p[0] == 54 { // page down
-			max := max(0, (tui.Model.printLines - tui.screensize))
-			// Always leave one line overlap for better orientation
-			tui.Model.offset = min(max, tui.Model.offset+tui.screensize-1)
 		}
 
 		// Forward keypress to listener


### PR DESCRIPTION
Add some minor improvements to the pagination feature:

* Display page count from the beginning onwards
* Add handlers for home, end, page up, page down and arrow left/right keys
* Use case instead of nested ifs in the openqa-revtui key handler

Follow-up of https://github.com/os-autoinst/openqa-mon/pull/157, in preparation of a Release-Candidate