### PR TITLE
Move project to os-autoinst

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 	"github.com/os-autoinst/openqa-mon/internal"
 )
 
@@ -62,7 +62,7 @@ func printHelp() {
 	fmt.Println("  --config FILE                    Read additional config file FILE")
 	fmt.Println("  -i, --input FILE                 Read jobs from FILE (additionally to stdin)")
 	fmt.Println("")
-	fmt.Println("2023, https://github.com/grisu48/openqa-mon")
+	fmt.Println("2024, https://github.com/os-autoinst/openqa-mon")
 }
 
 /** Try to match the url to be a test url. On success, return the remote and the job id */

--- a/cmd/openqa-mon/tui.go
+++ b/cmd/openqa-mon/tui.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 	"github.com/os-autoinst/openqa-mon/internal"
 	"golang.org/x/crypto/ssh/terminal"
 )

--- a/cmd/openqa-mon/util.go
+++ b/cmd/openqa-mon/util.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 )
 
 // Removes fragment from url

--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 	"github.com/os-autoinst/openqa-mon/internal"
 )
 
@@ -131,7 +131,7 @@ func printUsage() {
 	fmt.Println("    -n,--notify                         Enable notifications")
 	fmt.Println("    -m,--mute                           Disable notifications")
 	fmt.Println("")
-	fmt.Println("openqa-review is part of openqa-mon (https://github.com/grisu48/openqa-mon/)")
+	fmt.Println("openqa-review is part of openqa-mon (https://github.com/os-autoinst/openqa-mon/)")
 }
 
 // Register the given rabbitMQ instance for the tui

--- a/cmd/openqa-revtui/openqa.go
+++ b/cmd/openqa-revtui/openqa.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 )
 
 func hideJob(job gopenqa.Job) bool {

--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -13,7 +13,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/grisu48/gopenqa"
+	"github.com/os-autoinst/gopenqa"
 )
 
 // Declare ANSI color codes

--- a/doc/openqa-mon.8
+++ b/doc/openqa-mon.8
@@ -185,4 +185,4 @@ This tool has been created to help me and my colleagues work better with openQA.
 
 .SH
 .PP
-https://github.com/grisu48/openqa-mon openqa-mon(8)
+https://github.com/os-autoinst/openqa-mon openqa-mon(8)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	github.com/grisu48/gopenqa v0.7.4
+	github.com/os-autoinst/gopenqa v1.0.0
 	golang.org/x/crypto v0.25.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/grisu48/gopenqa v0.7.4 h1:E2IXKid1SJ2ndtzs3KNmYhFGcl8IX8eh2A2pYWD1CgU=
-github.com/grisu48/gopenqa v0.7.4/go.mod h1:+gXgBF7HsC/JjqQM5iSTEy9Ws9OlvJivALVYJRtXH+8=
+github.com/os-autoinst/gopenqa v1.0.0 h1:i0yMSm4zV6hrA8VdMfGFOfLK2TRr1nTtWQKszUyWXz0=
+github.com/os-autoinst/gopenqa v1.0.0/go.mod h1:nlYlp/pmUNz4cmJKzuBjkOpAN2pR6pY9OdU6GUu8zyo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=


### PR DESCRIPTION
Remove the last remaining links to github.com/grisu48 and move the project fully over to github.com/os-autoinst. This includes migrating the grisu48/gopenqa dependency to os-autoinst/gopenqa.

Related items:

* https://github.com/os-autoinst/gopenqa/releases/tag/v1.0.0
* https://github.com/os-autoinst/gopenqa/pull/42