### PR TITLE
Remove unneeded code

### DIFF
--- a/cmd/openqa-revtui/tui.go
+++ b/cmd/openqa-revtui/tui.go
@@ -705,17 +705,3 @@ func spaces(n int) string {
 	}
 	return ret
 }
-
-func max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}


### PR DESCRIPTION
'min' and 'max' functions are part of stdlib from go 1.21