### PR TITLE
Consider no arguments wrong usage

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -695,14 +695,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// No jobs and no remotes is considered wrong usage
 	if len(remotes) == 0 {
-		// Apply default remote, if defined
-		if config.DefaultRemote == "" {
-			printHelp()
-			return
-		}
-		remote := Remote{URI: config.DefaultRemote}
-		remotes = append(remotes, remote)
+		printHelp()
+		os.Exit(1)
 	}
 
 	// Remove duplicate IDs and sort jobs by ID


### PR DESCRIPTION
Consider running openqa-mon without job or explicit remote definition wrong program usage and terminate.

* Fixes https://github.com/os-autoinst/openqa-mon/issues/169

Note that using `openqa-mon JOBID` will still work, if a default remote is configured in any of the configuration files.