### PR TITLE
Refactor util with generics and cleanup

### DIFF
--- a/cmd/openqa-mon/openqa-mon.go
+++ b/cmd/openqa-mon/openqa-mon.go
@@ -229,17 +229,17 @@ func jobsContainId(jobs []gopenqa.Job, id int64) bool {
 func getJobHierarchy(job gopenqa.Job, follow bool) ([]gopenqa.Job, error) {
 	jobs := make([]gopenqa.Job, 0)
 	// TODO: The prefix got missing ...
-	chained, err := job.FetchChildren(unique64(job.Children.Chained), follow)
+	chained, err := job.FetchChildren(unique(job.Children.Chained), follow)
 	if err != nil {
 		return jobs, err
 	}
 	jobs = append(jobs, chained...)
-	directlyChained, err := job.FetchChildren(unique64(job.Children.DirectlyChained), follow)
+	directlyChained, err := job.FetchChildren(unique(job.Children.DirectlyChained), follow)
 	if err != nil {
 		return jobs, err
 	}
 	jobs = append(jobs, directlyChained...)
-	parallel, err := job.FetchChildren(unique64(job.Children.Parallel), follow)
+	parallel, err := job.FetchChildren(unique(job.Children.Parallel), follow)
 	if err != nil {
 		return jobs, err
 	}
@@ -703,7 +703,7 @@ func main() {
 
 	// Remove duplicate IDs and sort jobs by ID
 	for _, remote := range remotes {
-		remote.Jobs = unique64(remote.Jobs)
+		remote.Jobs = unique(remote.Jobs)
 		sort.Slice(remote.Jobs, func(i, j int) bool {
 			return remote.Jobs[i] < remote.Jobs[j]
 		})
@@ -809,7 +809,7 @@ func FetchJobs(remotes []Remote, callback func(int64, gopenqa.Job)) ([]Remote, e
 			}
 			if jobsModified {
 				// Ensure the job IDs are unique and sorted
-				jobs := unique64(remote.Jobs)
+				jobs := unique(remote.Jobs)
 				sort.Slice(jobs, func(i, j int) bool {
 					return jobs[i] < jobs[j]
 				})

--- a/cmd/openqa-mon/util.go
+++ b/cmd/openqa-mon/util.go
@@ -75,7 +75,7 @@ func homeDir() string {
 
 func createInt64Range(min int64, max int64, offset int64) []int64 {
 	// create with capacity to avoid runtime reallocation
-	ret := make([]int64, 0, 1+max-min)
+	ret := make([]int64, 0, (max-min)+1)
 	for i := min; i <= max; i++ {
 		ret = append(ret, i+offset)
 	}

--- a/cmd/openqa-mon/util.go
+++ b/cmd/openqa-mon/util.go
@@ -41,37 +41,16 @@ func max(x int, y int) int {
 	return y
 }
 
-func unique(a []int) []int {
-	keys := make(map[int]bool)
-	list := []int{}
-	for _, entry := range a {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
+func unique[T comparable](slice []T) []T {
+	seen := make(map[T]struct{})
+	unique := []T{}
+	for _, item := range slice {
+		if _, exists := seen[item]; !exists {
+			seen[item] = struct{}{}
+			unique = append(unique, item)
 		}
 	}
-	return list
-}
-
-func unique64(a []int64) []int64 {
-	keys := make(map[int64]bool)
-	list := []int64{}
-	for _, entry := range a {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
-		}
-	}
-	return list
-}
-
-func containsInt(a []int, cmp int) bool {
-	for _, i := range a {
-		if i == cmp {
-			return true
-		}
-	}
-	return false
+	return unique
 }
 
 func trimSplit(s string, sep string) []string {
@@ -94,16 +73,9 @@ func homeDir() string {
 	return usr.HomeDir
 }
 
-func createIntRange(min int, max int, offset int) []int {
-	ret := make([]int, 0)
-	for i := min; i <= max; i++ {
-		ret = append(ret, i+offset)
-	}
-	return ret
-}
-
 func createInt64Range(min int64, max int64, offset int64) []int64 {
-	ret := make([]int64, 0)
+	// create with capacity to avoid runtime reallocation
+	ret := make([]int64, 0, 1+max-min)
 	for i := min; i <= max; i++ {
 		ret = append(ret, i+offset)
 	}


### PR DESCRIPTION
With reference to issue #175 

- Introduce a generic implementation of unique()
- remove unused functions
- improve createInt64Range() performance by allocating all the needed data at start
