### PR TITLE
Remove MaxLifetime

### DIFF
--- a/_review/opensuse-bci.toml
+++ b/_review/opensuse-bci.toml
@@ -15,9 +15,7 @@ RequestJobLimit = 100                                           # Query up to 10
 [[Groups]]
 Name = "openSUSE Tumbleweed BCI x86_64"
 Params = { flavor = "BCI", groupid = "1" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "openSUSE Tumbleweed BCI aarch64"
 Params = { flavor = "BCI", groupid = "3" }
-MaxLifetime = 86400


### PR DESCRIPTION
There can be more than 24h difference between the x86_64 and aarch64 builds, so it makes sense to try to display both.