### PR TITLE
Set correct groupid to match with description

### DIFF
--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -262,7 +262,7 @@ MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE 15-SP6 WSL"
-Params = { groupid = "326" }
+Params = { groupid = "595" }
 MaxLifetime = 86400
 
 [[Groups]]


### PR DESCRIPTION
`SLE 15-SP6 WSL` group with such name has actually different ID than currently presented in main branch 