### PR TITLE
Fix panic when RequestJobLimit is not set

### DIFF
--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -34,6 +34,7 @@ func parseProgramArgs(cf *Config) ([]Config, error) {
 				}
 				filename := os.Args[i]
 				var cf Config
+				cf.RequestJobLimit = 100 // Set default limit
 				if err := cf.LoadToml(filename); err != nil {
 					return cfs, fmt.Errorf("in %s: %s", filename, err)
 				}

--- a/cmd/openqa-revtui/openqa.go
+++ b/cmd/openqa-revtui/openqa.go
@@ -103,9 +103,13 @@ func fetchJobsFollow(ids []int64, model *TUIModel, progress func(i, n int)) ([]g
 	// We split the job ids into multiple requests if necessary
 	jobs := make([]gopenqa.Job, 0)
 	// Progress variables
-	chunks := len(ids) / model.Config.RequestJobLimit
+	limit := model.Config.RequestJobLimit
+	if limit <= 0 {
+		limit = len(ids)
+	}
+	chunks := len(ids) / limit
 	for i := 0; len(ids) > 0; i++ { // Repeat until no more ids are available.
-		n := min(model.Config.RequestJobLimit, len(ids))
+		n := min(limit, len(ids))
 		chunk, err := model.Instance.GetJobsFollow(ids[:n])
 		if progress != nil {
 			progress(i, chunks)


### PR DESCRIPTION
If the `RequestJobLimit` is not set, it resulted in a panic. This commit fixes it by setting the limit to the job number in such cases.

* Fixes https://github.com/os-autoinst/openqa-mon/issues/190