### PR TITLE
Allow passing of overview links

### DIFF
--- a/cmd/openqa-revtui/config.go
+++ b/cmd/openqa-revtui/config.go
@@ -93,3 +93,12 @@ func LoadDefaultConfig() (Config, error) {
 	}
 	return cf, nil
 }
+
+func (cf *Config) SetRabbitO3() {
+	cf.RabbitMQ = "amqps://opensuse:opensuse@rabbit.opensuse.org"
+	cf.RabbitMQTopic = "opensuse.openqa.job.done"
+}
+func (cf *Config) SetRabbitOSD() {
+	cf.RabbitMQ = "amqps://suse:suse@rabbit.suse.de"
+	cf.RabbitMQTopic = "suse.openqa.job.done"
+}

--- a/cmd/openqa-revtui/openqa.go
+++ b/cmd/openqa-revtui/openqa.go
@@ -161,14 +161,13 @@ type FetchJobsCallback func(int, int, int, int)
 func FetchJobs(model *TUIModel, callback FetchJobsCallback) ([]gopenqa.Job, error) {
 	ret := make([]gopenqa.Job, 0)
 	for i, group := range model.Config.Groups {
-		params := group.Params
-		jobs, err := model.Instance.GetOverview("", params)
+		jobs, err := model.Instance.GetOverview("", group.Params)
 		if err != nil {
 			return ret, err
 		}
 
-		// Limit jobs to at most MaxJobs
-		if len(jobs) > model.Config.MaxJobs {
+		// Limit jobs to at most MaxJobs, if set (0 = unlimited)
+		if model.Config.MaxJobs > 0 && len(jobs) > model.Config.MaxJobs {
 			jobs = jobs[:model.Config.MaxJobs]
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/os-autoinst/openqa-mon
 
-go 1.21
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Adds ability to pass openQA overview links directly to revtui, so that a overview link from the browser can be pasted directly into the revtui tool.

This should make it easier to keep monitoring a certain job group without the need to parse parameters manually.