### PR TITLE
Update QE-C template

### DIFF
--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -9,6 +9,18 @@ MaxJobs = 20                                     # Max. job per group to display
 GroupBy = "groups"                               # Group by defined groups ("none" or "groups")
 RequestJobLimit = 100                            # Query up to 100 jobs per http request
 
+## Create host disks ###########################################################
+
+[[Groups]]
+Name = "Create bootable host HDDs"
+Params = { groupid = "377", build = "" }
+MaxLifetime = 432000 # 5 days
+
+[[Groups]]
+Name = "Create publiccloud-tools HDD"
+Params = { groupid = "276", build = "" }
+MaxLifetime = 432000 # 5 days
+
 ## Container Maintenance updates ###############################################
 
 [[Groups]]
@@ -38,14 +50,6 @@ Params = { groupid = "417", build = "%yesterday%-1", version="15-SP2" }
 [[Groups]]
 Name = "Containers Maintenance Updates 12-SP5"
 Params = { groupid = "417", build = "%yesterday%-1", version="12-SP5" }
-
-# Create host disk images
-
-[[Groups]]
-Name = "Create bootable host HDDs"
-Params = { groupid = "377", build = "" }
-MaxLifetime = 432000 # 5 days
-
 
 ## JeOS/MinimalVM Maintenance updates ##########################################
 
@@ -104,26 +108,6 @@ Params = { groupid = "427", build = "%yesterday%-1", version="12-SP5" }
 Name = "Public Cloud Single Incidents"
 Params = { groupid = "430" }
 MaxLifetime = 1209600 # 2 weeks
-
-# Create openQA helper instance disk image
-
-[[Groups]]
-Name = "Create publiccloud-tools HDD"
-Params = { groupid = "276", build = "" }
-MaxLifetime = 432000 # 5 days
-
-## SLE Micro image updates
-
-[[Groups]]
-Name = "SLE Micro Toolbox updates"
-Params = { groupid = "451" }
-MaxLifetime = 432000 # 5 days
-
-[[Groups]]
-Name = "SLE Micro for Rancher"
-Params = { groupid = "449" }
-MaxLifetime = 432000 # 5 days
-
 
 ## SLE Micro Maintenance updates ###############################################
 
@@ -214,6 +198,18 @@ Name = "SLE Micro Maintenance Incidents for 5.1"
 Params = { groupid = "482" }
 MaxLifetime = 432000 # 5 days
 
+
+## SLE Micro image updates
+
+[[Groups]]
+Name = "SLE Micro Toolbox updates"
+Params = { groupid = "451" }
+MaxLifetime = 432000 # 5 days
+
+[[Groups]]
+Name = "SLE Micro for Rancher"
+Params = { groupid = "449" }
+MaxLifetime = 432000 # 5 days
 
 ## WSL builds ##################################################################
 

--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -14,44 +14,37 @@ RequestJobLimit = 100                            # Query up to 100 jobs per http
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP7"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP7" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP6"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP6" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP5"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP5" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP4"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP4" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP3"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP3" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 15-SP2"
 Params = { groupid = "417", build = "%yesterday%-1", version="15-SP2" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "Containers Maintenance Updates 12-SP5"
 Params = { groupid = "417", build = "%yesterday%-1", version="12-SP5" }
-MaxLifetime = 86400
 
 # Create host disk images
 
 [[Groups]]
 Name = "Create bootable host HDDs"
 Params = { groupid = "377", build = "" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 
 ## JeOS/MinimalVM Maintenance updates ##########################################
@@ -59,37 +52,26 @@ MaxLifetime = 86400
 [[Groups]]
 Name = "JeOS Maintenance Updates 15-SP7"
 Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP7" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "JeOS Maintenance Updates 15-SP6"
 Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP6" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "JeOS Maintenance Updates 15-SP5"
 Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP5" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "JeOS Maintenance Updates 15-SP4"
 Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP4" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "JeOS Maintenance Updates 15-SP3"
 Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP3" }
-MaxLifetime = 86400
-
-[[Groups]]
-Name = "JeOS Maintenance Updates 15-SP2"
-Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP2" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "JeOS Maintenance Updates 12-SP5"
 Params = { groupid = "419", build = "%yesterday%-1", version = "12-SP5" }
-MaxLifetime = 86400
 
 
 ## PublicCloud Maintenance updates #############################################
@@ -121,26 +103,26 @@ Params = { groupid = "427", build = "%yesterday%-1", version="12-SP5" }
 [[Groups]]
 Name = "Public Cloud Single Incidents"
 Params = { groupid = "430" }
-MaxLifetime = 86400
+MaxLifetime = 1209600 # 2 weeks
 
 # Create openQA helper instance disk image
 
 [[Groups]]
 Name = "Create publiccloud-tools HDD"
 Params = { groupid = "276", build = "" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 ## SLE Micro image updates
 
 [[Groups]]
 Name = "SLE Micro Toolbox updates"
 Params = { groupid = "451" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro for Rancher"
 Params = { groupid = "449" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 
 ## SLE Micro Maintenance updates ###############################################
@@ -148,99 +130,89 @@ MaxLifetime = 86400
 [[Groups]]
 Name = "SL Micro 6.0 Staging Updates for Containers"
 Params = { groupid = "566" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SL Micro 6.0 Product Updates for Containers"
 Params = { groupid = "572" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SL Micro 6.0 Product Increments Public Cloud"
 Params = { groupid = "613", version="6.0" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SL Micro 6.1 Product Increments Public Cloud"
 Params = { groupid = "613", version="6.1" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.5"
 Params = { groupid = "420", build = "%yesterday%-1", version = "5.5" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.4"
 Params = { groupid = "420", build = "%yesterday%-1", version = "5.4" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.3"
 Params = { groupid = "420", build = "%yesterday%-1", version = "5.3" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.2"
 Params = { groupid = "420", build = "%yesterday%-1", version = "5.2" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.1"
 Params = { groupid = "420", build = "%yesterday%-1", version = "5.1" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.5 Public Cloud"
 Params = { groupid = "532", build = "%yesterday%-1", version = "5.5" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.4  Public Cloud"
 Params = { groupid = "532", build = "%yesterday%-1", version = "5.4" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.3  Public Cloud"
 Params = { groupid = "532", build = "%yesterday%-1", version = "5.3" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.2  Public Cloud"
 Params = { groupid = "532", build = "%yesterday%-1", version = "5.2" }
-MaxLifetime = 86400
 
 [[Groups]]
 Name = "SLE Micro Maintenance Updates 5.1  Public Cloud"
 Params = { groupid = "532", build = "%yesterday%-1", version = "5.1" }
-MaxLifetime = 86400
 
 ## Single Incidents SLE Micro
 
 [[Groups]]
 Name = "SLE Micro Maintenance Incidents for 5.5"
 Params = { groupid = "528" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro Maintenance Incidents for 5.4"
 Params = { groupid = "486" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro Maintenance Incidents for 5.3"
 Params = { groupid = "484" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro Maintenance Incidents for 5.2"
 Params = { groupid = "483" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE Micro Maintenance Incidents for 5.1"
 Params = { groupid = "482" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 
 ## WSL builds ##################################################################
@@ -248,21 +220,21 @@ MaxLifetime = 86400
 [[Groups]]
 Name = "SLE 15-SP6 WSL"
 Params = { groupid = "595" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "SLE 15-SP5 WSL"
 Params = { groupid = "461" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 ## Windows KVM Installation
 
 [[Groups]]
 Name = "Windows 11 installation"
 Params = { version="11", groupid="287" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days
 
 [[Groups]]
 Name = "Windows 10 installation"
 Params = { version="10", groupid="287" }
-MaxLifetime = 86400
+MaxLifetime = 432000 # 5 days


### PR DESCRIPTION
* Increases maximum lifetime of jobs without builds to not miss them over the weekend
* Remove deprecated 15-SP2 test runs
* Remove maximum lifetime for jobs bound to a build with a date