### PR TITLE
Revert "Bump uncenter/setup-taplo from 1 to 2"

### DIFF
--- a/.github/workflows/openqa-mon.yml
+++ b/.github/workflows/openqa-mon.yml
@@ -62,6 +62,6 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v6
       - name: 'Tomllint'
-        uses: uncenter/setup-taplo@v2
+        uses: uncenter/setup-taplo@v1
       - run: taplo fmt --check _review/*.toml
 


### PR DESCRIPTION
Reverts os-autoinst/openqa-mon#215 due to missing approval.