### PR TITLE
Restore "Bump uncenter/setup-taplo from 1 to 2"

### DIFF
--- a/.github/workflows/openqa-mon.yml
+++ b/.github/workflows/openqa-mon.yml
@@ -62,6 +62,6 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v6
       - name: 'Tomllint'
-        uses: uncenter/setup-taplo@v1
+        uses: uncenter/setup-taplo@v2
       - run: taplo fmt --check _review/*.toml
 


### PR DESCRIPTION
Restores https://github.com/os-autoinst/openqa-mon/pull/215 but now with approval.

The previous PR was reverted due to the requirement of having at least two approvals.