### PR TITLE
Fix: Do not crash when no jobs are returned

### DIFF
--- a/cmd/openqa-revtui/openqa-revtui.go
+++ b/cmd/openqa-revtui/openqa-revtui.go
@@ -256,7 +256,11 @@ func RefreshJobs() error {
 		ids = append(ids, job.ID)
 	}
 	callback := func(i, n int) {
-		tui.SetStatus(fmt.Sprintf("Refreshing %d jobs ... %d%% ", len(oldJobs), 100/n*i))
+		if n == 0 {
+			tui.SetStatus(fmt.Sprintf("Refreshing %d jobs ...", len(oldJobs)))
+		} else {
+			tui.SetStatus(fmt.Sprintf("Refreshing %d jobs ... %d%% ", len(oldJobs), 100/n*i))
+		}
 		tui.Update()
 	}
 	jobs, err := fetchJobsFollow(ids, model, callback)


### PR DESCRIPTION
Do not crash the program when no jobs are being returned from a job group.

Fixes https://github.com/os-autoinst/openqa-mon/issues/221