### PR TITLE
Include request parameters in error message

### DIFF
--- a/cmd/openqa-revtui/config.go
+++ b/cmd/openqa-revtui/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -101,4 +102,10 @@ func (cf *Config) SetRabbitO3() {
 func (cf *Config) SetRabbitOSD() {
 	cf.RabbitMQ = "amqps://suse:suse@rabbit.suse.de"
 	cf.RabbitMQTopic = "suse.openqa.job.done"
+}
+
+// Human readable representation of the group
+func (grp *Group) String() string {
+	buf, _ := json.Marshal(grp.Params)
+	return fmt.Sprintf("'%s' %s", grp.Name, string(buf))
 }

--- a/cmd/openqa-revtui/openqa.go
+++ b/cmd/openqa-revtui/openqa.go
@@ -163,7 +163,7 @@ func FetchJobs(model *TUIModel, callback FetchJobsCallback) ([]gopenqa.Job, erro
 	for i, group := range model.Config.Groups {
 		jobs, err := model.Instance.GetOverview("", group.Params)
 		if err != nil {
-			return ret, err
+			return ret, fmt.Errorf("%s in %s", err, group.String())
 		}
 
 		// Limit jobs to at most MaxJobs, if set (0 = unlimited)


### PR DESCRIPTION
Include the job group parameters when fetching a job group fails to give the user a hint where an error comes from.

Resolves https://github.com/os-autoinst/openqa-mon/issues/230

Before:

```
$ revtui qec
error fetching jobs: http status code 400
```

After:

```
$ revtui qec
error fetching jobs: http status code 400 in 'SL Micro 6.2 Product Increments - Public Cloud' {"groupid":"701"}
```