### PR TITLE
Remove non-existing group

### DIFF
--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -71,10 +71,6 @@ MaxLifetime = 604800
 Name = "SL Micro 6.2 Product Increments"
 Params = { groupid = "700" }
 MaxLifetime = 604800
-[[Groups]]
-Name = "SL Micro 6.2 Product Increments - Public Cloud"
-Params = { groupid = "701" }
-MaxLifetime = 604800
 
 ## Container Maintenance updates ###############################################
 


### PR DESCRIPTION
The SLEM 6.2 Product Increment group doesn't exist anymore.