### PR TITLE
Add release target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 /openqa-mon
 /openqa-revtui
 /openqa-mq
+/openqa-mon-*
+/openqa-revtui-*
+/openqa-mq-*
 # Temporary files
 /*.json

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,25 @@
 .PHONY: lint
 
 default: all
-static: openqa-mon-static openqa-mq-static openqa-revtui-static
 
 GOARGS=
 PREFIX=/usr/local/bin/
 
 all: openqa-mon openqa-mq openqa-revtui
-openqa-mon: cmd/openqa-mon/openqa-mon.go cmd/openqa-mon/config.go cmd/openqa-mon/tui.go cmd/openqa-mon/util.go
-	go build $(GOARGS) -o $@ $^
-openqa-mon-static: cmd/openqa-mon/openqa-mon.go cmd/openqa-mon/config.go cmd/openqa-mon/tui.go cmd/openqa-mon/util.go
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mon $^
-openqa-mq: cmd/openqa-mq/openqa-mq.go
-	go build $(GOARGS) -o $@ $^
-openqa-mq-static: cmd/openqa-mq/openqa-mq.go
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mq $^
-openqa-revtui: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go cmd/openqa-revtui/config.go
-	go build $(GOARGS) -o $@ $^
-openqa-revtui-static: cmd/openqa-revtui/openqa-revtui.go cmd/openqa-revtui/tui.go cmd/openqa-revtui/utils.go cmd/openqa-revtui/openqa.go cmd/openqa-revtui/config.go
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-revtui $^
+openqa-mon: cmd/openqa-mon/*.go internal/main.go
+	go build $(GOARGS) -o $@ cmd/openqa-mon/*.go
+openqa-mq: cmd/openqa-mq/*.go internal/main.go
+	go build $(GOARGS) -o $@ cmd/openqa-mq/*.go 
+openqa-revtui: cmd/openqa-revtui/*.go internal/main.go
+	go build $(GOARGS) -o $@ cmd/openqa-revtui/*.go
+
+release: cmd/openqa-mon/*.go cmd/openqa-revtui/*.go cmd/openqa-mq/*.go internal/main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-revtui-x86_64 cmd/openqa-revtui/*.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mq-x86_64 cmd/openqa-mq/*.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mon-x86_64 cmd/openqa-mon/*.go
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-revtui-aarch64 cmd/openqa-revtui/*.go
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mq-aarch64 cmd/openqa-mq/*.go
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o openqa-mon-aarch64 cmd/openqa-mon/*.go
 
 requirements:
 	go get ./...


### PR DESCRIPTION
Add a `release` target to the Makefile which builds static binaries for x86_64 and aarch64. This makes it possible for the next release to publish pre-build binaries also for aarch64.