### PR TITLE
Add missing QE-C job groups to review templates

### DIFF
--- a/_review/README.md
+++ b/_review/README.md
@@ -24,7 +24,8 @@ Individual files:
 * [qec-bci.toml](qec-bci.toml) - Review template for SLE BCI container images
 * [qec-minimalvm.toml](qec-minimalvm.toml) - Review template for MinimalVM/JeOS images
 * [qec-sle-micro.toml](qec-sle-micro.toml) - Review template for SLE Micro
-* [qec-wsl.toml](qec-wsl.toml) - Review template for SLE WSL images
+* [qec-qr.toml](qec-qr.toml) - Review template for Quarterly Refresh MinimalVM test runs
+* [qec-sles16-latest.toml](qec-sles16-latest.toml) - Review template for miscellaneous SLE 16 test runs (container host, minimal-VM, public cloud clients, transactional images)
 
 ## Create a TODO template
 

--- a/_review/qe-Maintenance-QEC.toml
+++ b/_review/qe-Maintenance-QEC.toml
@@ -116,7 +116,6 @@ Params = { groupid = "419", build = "%yesterday%-1", version = "15-SP4" }
 Name = "JeOS Maintenance Updates 12-SP5"
 Params = { groupid = "419", build = "%yesterday%-1", version = "12-SP5" }
 
-
 ## PublicCloud Maintenance updates #############################################
 
 [[Groups]]

--- a/_review/qec-publiccloud.toml
+++ b/_review/qec-publiccloud.toml
@@ -60,6 +60,10 @@ MaxLifetime = 86400
 Name = "PublicCloud Mainteanance Images - SAP"
 Params = { groupid = "640" }
 MaxLifetime = 86400
+[[Groups]]
+Name = "PublicCloud Mainteanance Images - SLEM"
+Params = { groupid = "653" }
+MaxLifetime = 86400
 
 [[Groups]]
 Name = "LTP Stable"

--- a/_review/qec-qr.toml
+++ b/_review/qec-qr.toml
@@ -1,0 +1,39 @@
+## Review template file for Quarterly Refresh MinimalVM test runs on OSD
+
+Instance = "https://openqa.suse.de" # openQA instance to query
+RabbitMQ = "amqps://suse:suse@rabbit.suse.de" # RabbitMQ instance to query
+RabbitMQTopic = "suse.openqa.job.done" # RabbitMQ topic to query
+HideStatus = [
+  "scheduled",
+  "passed",
+  "softfailed",
+  "cancelled",
+  "skipped",
+  "running",
+  "uploading",
+  "parallel_failed",
+  "reviewed",
+  "user_cancelled",
+] # Hide jobs in defined states
+RefreshInterval = 60 # Refresh from API once every minute
+MaxJobs = 20 # Max. job per group to display
+GroupBy = "groups" # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100 # Query up to 100 jobs per http request
+
+## Quarterly Refresh MinimalVM ##################################################
+
+[[Groups]]
+Name = "Maintenance - QR - SLE16.0-MinimalVM"
+Params = { groupid = "703" }
+
+[[Groups]]
+Name = "Maintenance - QR - 15SP7 MinimalVM"
+Params = { groupid = "450" }
+
+[[Groups]]
+Name = "Maintenance - QR - 15SP6 MinimalVM"
+Params = { groupid = "581" }
+
+[[Groups]]
+Name = "Maintenance - QR - 15SP5 MinimalVM"
+Params = { groupid = "374" }

--- a/_review/qec-sle-micro.toml
+++ b/_review/qec-sle-micro.toml
@@ -28,6 +28,16 @@ Name = "SLE Micro for Rancher"
 Params = { groupid = "449" }
 MaxLifetime = 86400
 
+[[Groups]]
+Name = "Container Host"
+Params = { groupid = "513" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Image config"
+Params = { groupid = "560" }
+MaxLifetime = 86400
+
 ## Maintenance updates #########################################################
 
 ## SL Micro

--- a/_review/qec-sles16-latest.toml
+++ b/_review/qec-sles16-latest.toml
@@ -1,0 +1,43 @@
+## Review template file for miscellaneous SLE 16 test runs on OSD
+
+Instance = "https://openqa.suse.de" # openQA instance to query
+RabbitMQ = "amqps://suse:suse@rabbit.suse.de" # RabbitMQ instance to query
+RabbitMQTopic = "suse.openqa.job.done" # RabbitMQ topic to query
+HideStatus = [
+  "scheduled",
+  "passed",
+  "softfailed",
+  "cancelled",
+  "skipped",
+  "running",
+  "uploading",
+  "parallel_failed",
+  "reviewed",
+  "user_cancelled",
+] # Hide jobs in defined states
+RefreshInterval = 60 # Refresh from API once every minute
+MaxJobs = 20 # Max. job per group to display
+GroupBy = "groups" # Group by defined groups ("none" or "groups")
+RequestJobLimit = 100 # Query up to 100 jobs per http request
+
+## SLE 16 ########################################################################
+
+[[Groups]]
+Name = "Container Host"
+Params = { groupid = "630" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Minimal-VM"
+Params = { groupid = "580" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Public Cloud clients"
+Params = { groupid = "626" }
+MaxLifetime = 86400
+
+[[Groups]]
+Name = "Transactional Images"
+Params = { groupid = "712" }
+MaxLifetime = 86400


### PR DESCRIPTION
Fills gaps found while auditing all QE-C squad job groups against the `_review` templates.

* Adds SL Micro's Container Host and Image config job groups to `qec-sle-micro.toml`.
* Adds Public Cloud's Maintenance Images - SLEM job group to `qec-publiccloud.toml` — confirmed against the squad's own reviewer-role documentation as an in-scope group missing from review coverage.
* Adds the Quarterly Refresh MinimalVM job groups in a new `qec-qr.toml`, kept separate from `qe-Maintenance-QEC.toml` since QR is not part of the maintenance updates workflow.
* Adds a new `qec-sles16-latest.toml` for four SLE 16 job groups (Container Host, Minimal-VM, Public Cloud clients, Transactional Images) that had no matching template file.